### PR TITLE
Homogenise attribute names

### DIFF
--- a/src/nomad_damask_parser/parsers/myparser.py
+++ b/src/nomad_damask_parser/parsers/myparser.py
@@ -53,10 +53,10 @@ class MyParser(MatchingParser):
         """
         section = increment.m_create(sections[0])
         for section_name, section_data in group[group_name].items():
-            section.homogenization_name = section_name
+            section.name = section_name
             field = section.m_create(sections[1])
             for field_name, field_data in section_data.items():
-                field.homogenization_field = field_name
+                field.name = field_name
                 for data_name, data_data in field_data.items():
                     self.extract_dataset(
                         data_name,
@@ -113,7 +113,7 @@ class MyParser(MatchingParser):
     def parse_increments(self):
         for increment_group in self.increments:
             increment = self.sec_data.m_create(damask.Increment)
-            increment.increment_name = increment_group.name
+            increment.name = increment_group.name
 
             geometry = increment.m_create(damask.GeometryDataset)
             for geo_name, geo_data in increment_group['geometry'].items():

--- a/src/nomad_damask_parser/schema_packages/mypackage.py
+++ b/src/nomad_damask_parser/schema_packages/mypackage.py
@@ -10,7 +10,7 @@
 #         BoundLogger,
 #     )
 
-from numpy import float64
+from numpy import dtype
 
 from nomad.config import config
 from nomad.datamodel.data import Schema
@@ -38,7 +38,7 @@ class Dataset(MSection):
     description = Quantity(
         type=str, description='Information about the nature of the dataset'
     )
-    data = Quantity(type=float64, shape=shape, description='Placeholder for now for the data')
+    data = Quantity(type=dtype('float64'), shape=shape, description='Placeholder for now for the data')
 
 
 

--- a/src/nomad_damask_parser/schema_packages/mypackage.py
+++ b/src/nomad_damask_parser/schema_packages/mypackage.py
@@ -44,36 +44,34 @@ class Dataset(MSection):
 
 ###############################################################################
 class PhaseField(MSection):
-    phase_field = Quantity(type=MEnum('mechanical', 'damage', 'thermal'))
-    phase_datasets = SubSection(sub_section=Dataset, repeats=True)
+    name = Quantity(type=MEnum('mechanical', 'damage', 'thermal'))
+    datasets = SubSection(sub_section=Dataset, repeats=True)
 
 class PhaseName(MSection):
-    phase_name = Quantity(type=str, description='User defined name of the phase')
-    phase_fields = SubSection(sub_section=PhaseField, repeats=True)
+    name = Quantity(type=str, description='User defined name of the phase')
+    fields = SubSection(sub_section=PhaseField, repeats=True)
 
 
 class HomogenizationField(MSection):
-    homogenization_field = Quantity(type=MEnum('mechanical', 'damage', 'thermal'))
-    homogenization_datasets = SubSection(sub_section=Dataset, repeats=True)
+    name = Quantity(type=MEnum('mechanical', 'damage', 'thermal'))
+    datasets = SubSection(sub_section=Dataset, repeats=True)
 
 class HomogenizationName(MSection):
-    homogenization_name = Quantity(
-        type=str, description='User defined name of the homogenization'
-    )
-    homogenization_fields = SubSection(sub_section=HomogenizationField, repeats=True)
+    name = Quantity(type=str, description='User defined name of the homogenization')
+    fields = SubSection(sub_section=HomogenizationField, repeats=True)
 
 
 class GeometryDataset(MSection):
-    geometry_datasets = SubSection(sub_section=Dataset, repeats=True)
+    datasets = SubSection(sub_section=Dataset, repeats=True)
 
 
 class Increment(MSection):
-    increment_name = Quantity(type=str, description='Name of the increment')
-    increment_geometry = SubSection(sub_section=GeometryDataset, repeats=False)
-    increment_homogenization = SubSection(
+    name = Quantity(type=str, description='Name of the increment')
+    geometry = SubSection(sub_section=GeometryDataset, repeats=False)
+    homogenization = SubSection(
         sub_section=HomogenizationName, repeats=True
     )
-    increment_phase = SubSection(sub_section=PhaseName, repeats=True)
+    phase = SubSection(sub_section=PhaseName, repeats=True)
 
 
 ###############################################################################
@@ -83,7 +81,7 @@ class SetupFile(MSection):
 
 class Setup(MSection):
     description = Quantity(type=str, description='Information about the setup section')
-    setup_filenames = SubSection(sub_section=SetupFile, repeats=True)
+    filenames = SubSection(sub_section=SetupFile, repeats=True)
 
 
 ###############################################################################
@@ -104,7 +102,7 @@ class CellTo(MSection):
     description = Quantity(
         type=str, description='Information about the cell_to section'
     )
-    cell_to_datasets = SubSection(sub_section=CompoundDataset, repeats=True)
+    datasets = SubSection(sub_section=CompoundDataset, repeats=True)
 
 
 ###############################################################################


### PR DESCRIPTION
Remove the specific prefix name in the name of the attributes of the schema classes.
It allows to manipulate more uniformly each of the class.

Change the type handling the data in the Dataset class to test if it mitigates the 'undefined unknown' dimension seen on the datasets extracted in NOMAD.