### PR TITLE
Correct the creation of subsection in increment_nn

### DIFF
--- a/src/nomad_damask_parser/parsers/myparser.py
+++ b/src/nomad_damask_parser/parsers/myparser.py
@@ -51,8 +51,8 @@ class MyParser(MatchingParser):
         group_name: name of the HDF5 group
         sections: list of the sub-sections inside the HDF5 group
         """
-        section = increment.m_create(sections[0])
         for section_name, section_data in group[group_name].items():
+            section = increment.m_create(sections[0])
             section.name = section_name
             field = section.m_create(sections[1])
             for field_name, field_data in section_data.items():


### PR DESCRIPTION
Extract separately each of the subsection in `phase` and `homogenization`.
Before, all subsubsections were gathered into only one subsection named after the last subsection parsed.

Before:
C
|-mechanical
|-mechanical
|-mechanical

instead of:
A
|-mechanical
B
|-mechanical
C
|-mechanical